### PR TITLE
Use the full kiosk url

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@ Integrate FusionSolar into you Home Assistant.
 FusionSolar has a kiosk mode. When this kiosk mode is enabled we can access 
 data about our plants through a JSON REST api.
 
+{% if installed %}
+{% if version_installed.replace("v", "").replace(".","") | int < 300  %}
+## Breaking Changes
+### Use the full kiosk url (since v3.0.0)
+Your current configuration should be updated. Before v3.0.0 we used the kiosk id. 
+Starting with v3.0.0 the full kiosk url should be used:
+
+    sensor:
+      - platform: fusion_solar_kiosk
+        kiosks:
+          - url: "REPLACE THIS WITH THE KIOSK URL"
+            name: "A readable name for the plant"
+
+See the "Configuration" section for more details
+{% endif %}
+{% endif %}
 
 ## Installation
 At this point the integration is not part of the default HACS repositories, so

--- a/README.md
+++ b/README.md
@@ -20,29 +20,24 @@ When this is done, just install the repository.
 The configuration of this integration happens in a few steps:
 
 ### Enable kiosk mode
-1. Sign in on the Huawei FusionSolar portal: [https://region04eu5.fusionsolar.huawei.com/](https://region04eu5.fusionsolar.huawei.com/).
-2. At the top there is a link: Kiosk View, click it.
-3. An overlay will open, and you need to enable the kioks view by enabling the toggle.
+1. Sign in on the Huawei FusionSolar portal: [https://eu5.fusionsolar.huawei.com/](https://eu5.fusionsolar.huawei.com/).
+2. Select your plant if needed.
+2. At the top there is a button: "Kiosk", click it.
+3. An overlay will open, and you need to enable the kiosk view by enabling the toggle.
 4. Note down the url that is shown.
-
-We only need the unique id, which is located just after the `kk=`. So if your
-url is `https://eu5.fusionsolar.huawei.com/singleKiosk.html?kk=XXXXX` the id is:
-`XXXXX`.
 
 ### Add into configuration
 Open your `configuration.yaml`, add the code below:
 
     sensor:
-        - platform: fusion_solar_kiosk
+      - platform: fusion_solar_kiosk
         kiosks:
-            - id: "XXXXX"
+          - url: "REPLACE THIS WITH THE KIOSK URL"
             name: "A readable name for the plant"
 
-Make sure you replace the `XXXXX`, with the unique id.
-
 ### Use secrets
-I would advice to store the unique id as a secret. With this uniaue token
-anybody can access your kiosk url, so be carefull to share this.
+I strongly advise to store the unique urls as a secret. The kiosk url is public, 
+so anybody with the link can access your data. Be careful when sharing this.
 
 More information on secrets: [Storing secrets](https://www.home-assistant.io/docs/configuration/secrets/).
 
@@ -50,31 +45,9 @@ More information on secrets: [Storing secrets](https://www.home-assistant.io/doc
 You can configure multiple plants:
 
     sensor:
-        - platform: fusion_solar_kiosk
+      - platform: fusion_solar_kiosk
         kiosks:
-            - id: "XXXXX"
-            name: "A readable name for plant XXXXX"
-            - id: "YYYYY"
-            name: "A readable name for plant YYYYY"
-
-
-## Future plans
-
-No of the items below are promises, so don't expect anything to happen soon:
-
-### Build a view
-Make a custom view that shows everything in a single card.
-
-Possible inspiration:
-* https://home-assistant-cards.bessarabov.com/
-* https://github.com/denysdovhan/vacuum-card
-* https://community.home-assistant.io/t/lovelace-power-wheel-card/82374
-* https://community.home-assistant.io/t/solar-pv-system-card/80218
-* https://github.com/gurbyz/power-wheel-card
-* https://github.com/reptilex/tesla-style-solar-power-card
-
-### Add power chart
-Add the power chart
-
-### Add social contributions
-Add the social contributions
+            - url: "KIOSK URL XXXXX"
+              name: "A readable name for plant XXXXX"
+            - url: "KIOSK URL YYYYY"
+              name: "A readable name for plant YYYYY"

--- a/custom_components/fusion_solar_kiosk/const.py
+++ b/custom_components/fusion_solar_kiosk/const.py
@@ -5,6 +5,7 @@ DOMAIN = 'fusion_solar_kiosk'
 
 # Configuration
 CONF_KIOSKS = 'kiosks'
+CONF_KIOSK_URL = 'url'
 
 
 # Fusion Solar Kiosk API response attributes

--- a/custom_components/fusion_solar_kiosk/fusion_solar_kiosk_api.py
+++ b/custom_components/fusion_solar_kiosk/fusion_solar_kiosk_api.py
@@ -26,9 +26,7 @@ class FusionSolarKioksApi:
 
         try:
             response = get(url, headers=headers)
-
             # _LOGGER.debug(response.text)
-
             jsonData = response.json()
 
             if not jsonData[ATTR_SUCCESS]:
@@ -36,7 +34,8 @@ class FusionSolarKioksApi:
 
             # convert encoded html string to JSON
             jsonData[ATTR_DATA] = json.loads(html.unescape(jsonData[ATTR_DATA]))
-
+            _LOGGER.debug('Received data for ' + id + ': ')
+            _LOGGER.debug(jsonData[ATTR_DATA][ATTR_DATA_REALKPI])
             return jsonData[ATTR_DATA][ATTR_DATA_REALKPI]
 
         except FusionSolarKioskApiError as error:

--- a/custom_components/fusion_solar_kiosk/sensor.py
+++ b/custom_components/fusion_solar_kiosk/sensor.py
@@ -9,7 +9,6 @@ from . import FusionSolarKioskEnergyEntity, FusionSolarKioskPowerEntity
 from datetime import timedelta
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_ID,
     CONF_NAME,
 )
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -17,7 +16,7 @@ from .const import *
 
 KIOSK_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_ID): cv.string,
+        vol.Required(CONF_KIOSK_URL): cv.string,
         vol.Required(CONF_NAME): cv.string
     }
 )

--- a/custom_components/fusion_solar_kiosk/sensor.py
+++ b/custom_components/fusion_solar_kiosk/sensor.py
@@ -14,6 +14,9 @@ from homeassistant.const import (
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import *
 
+import re
+from urllib.parse import urlparse
+
 KIOSK_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_KIOSK_URL): cv.string,
@@ -32,15 +35,14 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     async def async_update_data():
         """Fetch data"""
-        api = FusionSolarKioksApi('https://region04eu5.fusionsolar.huawei.com')
         data = {}
-        for kiosk in config[CONF_KIOSKS]:
-            data[kiosk['id']] = {
-                ATTR_DATA_REALKPI: await hass.async_add_executor_job(api.getRealTimeKpi, kiosk['id'])
+        for kioskConfig in config[CONF_KIOSKS]:
+            kiosk = Kiosk(kioskConfig['url'], kioskConfig['name'])
+            api = FusionSolarKioksApi(kiosk.apiUrl())
+            data[kiosk.id] = {
+                ATTR_DATA_REALKPI: await hass.async_add_executor_job(api.getRealTimeKpi, kiosk.id)
             }
-
         return data
-
 
     coordinator = DataUpdateCoordinator(
         hass,
@@ -53,56 +55,68 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_refresh()
 
-    async_add_entities(
-        FusionSolarKioskSensorRealtimePower(
-            coordinator,
-            kiosk['id'],
-            kiosk['name'],
-            ID_REALTIME_POWER,
-            NAME_REALTIME_POWER,
-            ATTR_REALTIME_POWER,
-        ) for kiosk in config[CONF_KIOSKS]
-    )
-    async_add_entities(
-        FusionSolarKioskSensorTotalCurrentDayEnergy(
-            coordinator,
-            kiosk['id'],
-            kiosk['name'],
-            ID_TOTAL_CURRENT_DAY_ENERGY,
-            NAME_TOTAL_CURRENT_DAY_ENERGY,
-            ATTR_TOTAL_CURRENT_DAY_ENERGY,
-        ) for kiosk in config[CONF_KIOSKS]
-    )
-    async_add_entities(
-        FusionSolarKioskSensorTotalCurrentMonthEnergy(
-            coordinator,
-            kiosk['id'],
-            kiosk['name'],
-            ID_TOTAL_CURRENT_MONTH_ENERGY,
-            NAME_TOTAL_CURRENT_MONTH_ENERGY,
-            ATTR_TOTAL_CURRENT_MONTH_ENERGY,
-        ) for kiosk in config[CONF_KIOSKS]
-    )
-    async_add_entities(
-        FusionSolarKioskSensorTotalCurrentYearEnergy(
-            coordinator,
-            kiosk['id'],
-            kiosk['name'],
-            ID_TOTAL_CURRENT_YEAR_ENERGY,
-            NAME_TOTAL_CURRENT_YEAR_ENERGY,
-            ATTR_TOTAL_CURRENT_YEAR_ENERGY,
-        ) for kiosk in config[CONF_KIOSKS]
-    )
-    async_add_entities(
-        FusionSolarKioskSensorTotalLifetimeEnergy(
-            coordinator,
-            kiosk['id'],
-            kiosk['name'],
-            ID_TOTAL_LIFETIME_ENERGY,
-            NAME_TOTAL_LIFETIME_ENERGY,
-            ATTR_TOTAL_LIFETIME_ENERGY,
-        ) for kiosk in config[CONF_KIOSKS]
-    )
+    for kioskConfig in config[CONF_KIOSKS]:
+        kiosk = Kiosk(kioskConfig['url'], kioskConfig['name'])
+
+        async_add_entities([
+            FusionSolarKioskSensorRealtimePower(
+                coordinator,
+                kiosk.id,
+                kiosk.name,
+                ID_REALTIME_POWER,
+                NAME_REALTIME_POWER,
+                ATTR_REALTIME_POWER,
+            ),
+            FusionSolarKioskSensorTotalCurrentDayEnergy(
+                coordinator,
+                kiosk.id,
+                kiosk.name,
+                ID_TOTAL_CURRENT_DAY_ENERGY,
+                NAME_TOTAL_CURRENT_DAY_ENERGY,
+                ATTR_TOTAL_CURRENT_DAY_ENERGY,
+            ),
+            FusionSolarKioskSensorTotalCurrentMonthEnergy(
+                coordinator,
+                kiosk.id,
+                kiosk.name,
+                ID_TOTAL_CURRENT_MONTH_ENERGY,
+                NAME_TOTAL_CURRENT_MONTH_ENERGY,
+                ATTR_TOTAL_CURRENT_MONTH_ENERGY,
+            ),
+            FusionSolarKioskSensorTotalCurrentYearEnergy(
+                coordinator,
+                kiosk.id,
+                kiosk.name,
+                ID_TOTAL_CURRENT_YEAR_ENERGY,
+                NAME_TOTAL_CURRENT_YEAR_ENERGY,
+                ATTR_TOTAL_CURRENT_YEAR_ENERGY,
+            ),
+            FusionSolarKioskSensorTotalLifetimeEnergy(
+                coordinator,
+                kiosk.id,
+                kiosk.name,
+                ID_TOTAL_LIFETIME_ENERGY,
+                NAME_TOTAL_LIFETIME_ENERGY,
+                ATTR_TOTAL_LIFETIME_ENERGY,
+            )
+        ])
+
+class Kiosk:
+    def __init__(self, url, name):
+        self.url = url
+        self.name = name
+        self._parseId()
+
+    def _parseId(self):
+        id = re.search("\?kk=(.*)", self.url).group(1)
+        _LOGGER.debug('calculated KioskId: ' + id)
+        self.id = id
+
+    def apiUrl(self):
+        url = urlparse(self.url)
+        apiUrl = (url.scheme + "://" + url.netloc)
+        _LOGGER.debug('calculated API base url for ' + self.id + ': ' + apiUrl)
+        return apiUrl
 
 
 class FusionSolarKioskSensorRealtimePower(FusionSolarKioskPowerEntity):


### PR DESCRIPTION
The kiosks can have different urls, so we can't hardcode the base url. Instead of just using the KioskId in the configuration we now us the full KioskUrl

Your current configuration should be updated. Before v3.0.0 we used the kiosk id. Starting with v3.0.0 the full kiosk url should be used:

    sensor:
      - platform: fusion_solar_kiosk
        kiosks:
          - url: "REPLACE THIS WITH THE KIOSK URL"
            name: "A readable name for the plant"

See the [Configuration](https://github.com/tijsverkoyen/Home-Assisant-FusionSolar-Kiosk#configuration) section for more details