### PR TITLE
Added validation of lifetime energy, fixing issue #28

### DIFF
--- a/custom_components/fusion_solar_kiosk/fusion_solar_kiosk_api.py
+++ b/custom_components/fusion_solar_kiosk/fusion_solar_kiosk_api.py
@@ -8,17 +8,23 @@ from .const import (
     ATTR_FAIL_CODE,
     ATTR_SUCCESS,
     ATTR_DATA_REALKPI,
+    ATTR_TOTAL_LIFETIME_ENERGY,
 )
 
 from requests import get
 
 _LOGGER = logging.getLogger(__name__)
 
+lastGoodLifetimeEnergy = {}
+
 class FusionSolarKioksApi:
     def __init__(self, host):
         self._host = host
 
     def getRealTimeKpi(self, id: str):
+
+        global lastGoodLifetimeEnergy
+
         url = self._host + '/rest/pvms/web/kiosk/v1/station-kiosk-file?kk=' + id
         headers = {
             'accept': 'application/json',
@@ -36,6 +42,17 @@ class FusionSolarKioksApi:
             jsonData[ATTR_DATA] = json.loads(html.unescape(jsonData[ATTR_DATA]))
             _LOGGER.debug('Received data for ' + id + ': ')
             _LOGGER.debug(jsonData[ATTR_DATA][ATTR_DATA_REALKPI])
+
+            # Validate response
+            if id not in lastGoodLifetimeEnergy:
+                lastGoodLifetimeEnergy[id] = 0
+
+            if jsonData[ATTR_DATA][ATTR_DATA_REALKPI][ATTR_TOTAL_LIFETIME_ENERGY] < lastGoodLifetimeEnergy[id]:
+                jsonData[ATTR_DATA][ATTR_DATA_REALKPI][ATTR_TOTAL_LIFETIME_ENERGY] = lastGoodLifetimeEnergy[id]
+                _LOGGER.debug(jsonData[ATTR_DATA][ATTR_DATA_REALKPI])
+            else:
+                lastGoodLifetimeEnergy[id] = jsonData[ATTR_DATA][ATTR_DATA_REALKPI][ATTR_TOTAL_LIFETIME_ENERGY]
+
             return jsonData[ATTR_DATA][ATTR_DATA_REALKPI]
 
         except FusionSolarKioskApiError as error:


### PR DESCRIPTION
A python-rookie attempt to fix, or work around, issue #28 . The real fix should be done by Huawei at their end.
It works but I really do not like the global, must be another way to retrieve previous energy value. But then again that would mean a low level API poking into upper layers, not nice either. 
